### PR TITLE
fix: Argument name in config

### DIFF
--- a/src/Resources/config/http_mock_context.xml
+++ b/src/Resources/config/http_mock_context.xml
@@ -9,7 +9,7 @@
             <argument key="$extendedHttpMockClientCollection" type="service" id="BehatHttpMockContext\Collection\ExtendedHttpMockClientCollection"/>
         </service>
         <service public="true" autowire="true" id="BehatHttpMockContext\Collection\ExtendedHttpMockClientCollection" class="BehatHttpMockContext\Collection\ExtendedHttpMockClientCollection">
-            <argument key="$handlers" type="tagged_iterator" tag="mock.http_client"/>
+            <argument key="$httpClients" type="tagged_iterator" tag="mock.http_client"/>
         </service>
     </services>
 </container>

--- a/tests/Integration/DependencyInjection/BehatHttpMockContextExtensionTest.php
+++ b/tests/Integration/DependencyInjection/BehatHttpMockContextExtensionTest.php
@@ -22,7 +22,7 @@ class BehatHttpMockContextExtensionTest extends TestCase
         $collectionDefinition = $container->getDefinition(ExtendedHttpMockClientCollection::class);
         self::assertSame(ExtendedHttpMockClientCollection::class, $collectionDefinition->getClass());
 
-        $handlersArgument = $collectionDefinition->getArgument('$handlers');
+        $handlersArgument = $collectionDefinition->getArgument('$httpClients');
         self::assertInstanceOf(TaggedIteratorArgument::class, $handlersArgument);
         self::assertSame(
             'mock.http_client',


### PR DESCRIPTION
The name did not match the one in class, which was breaking the library in a project with Symfony 7 components